### PR TITLE
Update grafana directories tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,11 +80,11 @@
     state=directory
   become: yes
   with_items:
-    - grafana_dir_conf
-    - grafana_dir_data
-    - grafana_dir_home
-    - grafana_dir_log
-    - grafana_dir_plugins
+    - "{{ grafana_dir_conf }}"
+    - "{{ grafana_dir_data }}"
+    - "{{ grafana_dir_home }}"
+    - "{{ grafana_dir_log }}"
+    - "{{ grafana_dir_plugins }}"
 
 - name: ensure grafana is running and enabled to start on boot
   service:


### PR DESCRIPTION
I think there the way those variables are referenced is incorrect. Running this role as the current state ends creating the following directories in the user's home used with ansible

```
grafana_dir_conf  grafana_dir_data  grafana_dir_home  grafana_dir_log  grafana_dir_plugins
```