### PR TITLE
fix new grafana versions not starting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,3 +96,4 @@ grafana_default:
   max_open_files: 10000
   plugins_dir: "{{ grafana_dir_plugins }}"
   restart_on_upgrade: 'false'
+  pid_file_dir: '/var/run/grafana'


### PR DESCRIPTION
imports a fix that sets a PID_FILE_DIR variable in /etc/defaults/grafana-server

see https://github.com/grafana/grafana/issues/9133
see https://github.com/grafana/grafana/commit/c3cffeb10ccd586b21774d54a1ebf434fddb2112#diff-ad598638c92a28d5d7ffdaba305d92b2