### PR TITLE
Fix problem with provisioning Grafana on Ubuntu 16.04+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ grafana_dir_data: /var/lib/grafana
 grafana_dir_home: /usr/share/grafana
 grafana_dir_log: /var/log/grafana
 grafana_dir_plugins: /var/lib/grafana/plugins
+grafana_dir_pid: /var/run/grafana
 grafana_http_port: 3000
 grafana_group: grafana
 grafana_user: grafana
@@ -96,3 +97,4 @@ grafana_default:
   max_open_files: 10000
   plugins_dir: "{{ grafana_dir_plugins }}"
   restart_on_upgrade: 'false'
+  pid_file_dir: "{{ grafana_dir_pid }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
     - "{{ grafana_dir_home }}"
     - "{{ grafana_dir_log }}"
     - "{{ grafana_dir_plugins }}"
+    - "{{ grafana_dir_pid }}"
 
 - name: ensure grafana is running and enabled to start on boot
   service:


### PR DESCRIPTION
Added pid_file_dir default value and pid file directory creation (required for Systemd service)