### PR TITLE
Fix grafana-server startup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ grafana_dir_data: /var/lib/grafana
 grafana_dir_home: /usr/share/grafana
 grafana_dir_log: /var/log/grafana
 grafana_dir_plugins: /var/lib/grafana/plugins
+grafana_pid_file_dir: /var/run/grafana
+grafana_pid_file: /var/run/grafana/grafana-server.pid
 grafana_http_port: 3000
 grafana_group: grafana
 grafana_user: grafana
@@ -96,3 +98,5 @@ grafana_default:
   max_open_files: 10000
   plugins_dir: "{{ grafana_dir_plugins }}"
   restart_on_upgrade: 'false'
+  pid_file_dir: "{{ grafana_pid_file_dir }}"
+  pid_file: "{{ grafana_pid_file }}"

--- a/tasks/debug.yml
+++ b/tasks/debug.yml
@@ -24,3 +24,5 @@
     - grafana_group
     - grafana_user
     - grafana_database
+    - grafana_pid_file_dir
+    - grafana_pid_file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,15 @@
   notify: restart grafana
   tags: configuration
 
+- name: ensure grafana pid directory is present
+  file:
+    path="{{ grafana_pid_dir }}"
+    owner="{{ grafana_user }}"
+    group="{{ grafana_group }}"
+    mode=0755
+    state=directory
+  become: yes
+    
 - name: ensure grafana directories ownership and permissions
   file:
     path="{{ item }}"
@@ -85,6 +94,7 @@
     - "{{ grafana_dir_home }}"
     - "{{ grafana_dir_log }}"
     - "{{ grafana_dir_plugins }}"
+    - "{{ grafana_pid_dir }}"
 
 - name: ensure grafana is running and enabled to start on boot
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
 
 - name: ensure grafana pid directory is present
   file:
-    path="{{ grafana_pid_dir }}"
+    path="{{ grafana_pid_file_dir }}"
     owner="{{ grafana_user }}"
     group="{{ grafana_group }}"
     mode=0755
@@ -94,7 +94,7 @@
     - "{{ grafana_dir_home }}"
     - "{{ grafana_dir_log }}"
     - "{{ grafana_dir_plugins }}"
-    - "{{ grafana_pid_dir }}"
+    - "{{ grafana_pid_file_dir }}"
 
 - name: ensure grafana is running and enabled to start on boot
   service:

--- a/tasks/validation.yml
+++ b/tasks/validation.yml
@@ -25,3 +25,5 @@
     - grafana_group
     - grafana_user
     - grafana_database
+    - grafana_pid_file_dir
+    - grafana_pid_file


### PR DESCRIPTION
I have found that both variables below were missing on the `/etc/default/grafana-server` config file and it is required for start up:
`PID_FILE_DIR=/var/run/grafana`
`PID_FILE=/var/run/grafana/grafana-server.pid`

After adding these 2 variables grafana-server.service will start normally.