### PR TITLE
Use items() instead of iteritems() in templates

### DIFF
--- a/templates/grafana-server.j2
+++ b/templates/grafana-server.j2
@@ -1,4 +1,4 @@
 # {{ ansible_managed }}
-{% for parameter, value in grafana_default.iteritems() %}
+{% for parameter, value in grafana_default.items() %}
 {{ parameter | upper }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
in order to be compatible with both python 2 & 3 (see https://docs.ansible.com/ansible/2.6/user_guide/playbooks_python_version.html#dict-iteritems)