### PR TITLE
Change repo url

### DIFF
--- a/defaults/debian-debian.yml
+++ b/defaults/debian-debian.yml
@@ -6,5 +6,3 @@
 
 grafana_apt_dependencies:
   - apt-transport-https
-
-grafana_apt_distribution: "{{ ansible_distribution_release | lower }}"

--- a/defaults/debian-ubuntu.yml
+++ b/defaults/debian-ubuntu.yml
@@ -5,5 +5,3 @@
 #
 
 grafana_apt_dependencies: []
-
-grafana_apt_distribution: wheezy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@
 #
 
 grafana_version: 5.4.3
+grafana_gpg_key_id: 24098CB6
 grafana_admin_password: admin
 grafana_admin_user: admin
 grafana_conf_file: /etc/grafana/grafana.ini

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # defaults file
 #
 
+grafana_version: 5.4.3
 grafana_admin_password: admin
 grafana_admin_user: admin
 grafana_conf_file: /etc/grafana/grafana.ini

--- a/tasks/debug.yml
+++ b/tasks/debug.yml
@@ -11,7 +11,6 @@
     - grafana_admin_password
     - grafana_admin_user
     - grafana_apt_dependencies
-    - grafana_apt_distribution
     - grafana_conf_data
     - grafana_conf_file
     - grafana_default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,15 +28,15 @@
 
 - name: ensure grafana apt key is present
   apt_key:
-    url=https://packagecloud.io/gpg.key
-    id=D59097AB
+    url=https://packages.grafana.com/gpg.key
+    id=24098CB6
     state=present
   become: yes
   tags: [ apt ]
 
 - name: ensure grafana apt repository is present
   apt_repository:
-    repo="deb https://packagecloud.io/grafana/stable/{{ ansible_os_family | lower }}/ {{ grafana_apt_distribution }} main"
+    repo="deb https://packages.grafana.com/oss/deb stable main"
     update_cache=yes
     state=present
   become: yes
@@ -44,7 +44,7 @@
 
 - name: ensure grafana is installed
   apt:
-    name=grafana
+    name="grafana={{ grafana_version }}"
     state=present
   become: yes
   tags: installation
@@ -79,7 +79,7 @@
     mode=0755
     state=directory
   become: yes
-    
+
 - name: ensure grafana directories ownership and permissions
   file:
     path="{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: ensure grafana apt key is present
   apt_key:
     url=https://packages.grafana.com/gpg.key
-    id=24098CB6
+    id="{{ grafana_gpg_key_id }}"
     state=present
   become: yes
   tags: [ apt ]

--- a/tasks/validation.yml
+++ b/tasks/validation.yml
@@ -12,7 +12,6 @@
     - grafana_admin_password
     - grafana_admin_user
     - grafana_apt_dependencies
-    - grafana_apt_distribution
     - grafana_conf_data
     - grafana_conf_file
     - grafana_default


### PR DESCRIPTION
Since grafana moved to self-hosted repository ( https://grafana.com/blog/2019/01/05/moving-to-packages.grafana.com/ ) and packagecloud.io key is expired, I update role and made following changes:

* Set apt_key and grafana version as variables
* Change url for apt repo
* Remove unused grafana_apt_distribution variable